### PR TITLE
Fix cron config: update Discord port, NAS IP, and paths

### DIFF
--- a/bin/parents-db-cron.sh
+++ b/bin/parents-db-cron.sh
@@ -3,14 +3,14 @@
 # Function to send Discord notification
 send_discord_notification() {
     local message="$1"
-    curl -X POST http://localhost:30008/alert \
+    curl -X POST http://localhost:30007/alert \
         -H "Content-Type: application/json" \
         -d "{\"message\": \"$message\"}" \
         --silent --show-error
 }
 
 # Configurable variables
-NAS_IP=195.168.1.14
+NAS_IP=10.20.0.18
 NAS_USER=$PARENTS_FINANCE_FTP_USER
 NAS_PASSWORD=$PARENTS_FINANCE_FTP_PASS
 GIT_PATH="/home/nathan/git/mypersonalfinance"

--- a/bin/parents-db-cron.sh
+++ b/bin/parents-db-cron.sh
@@ -30,14 +30,15 @@ files_to_process=(
 
 failed_files=()
 
+cd $GIT_PATH        
 for file in "${files_to_process[@]}"; do
     echo "Processing $file"
-    if ! uv run python "$GIT_PATH/load-excel-transactions.py" --filepath "$file" --cron true; then
+    if ! uv run python load-excel-transactions.py --filepath "$file" --cron true; then
         echo "ERROR: Failed to process $file"
         failed_files+=("$file")
-    fi
+    fi    
 done
-
+cd -
 # Send Discord notification if any files failed
 if [ ${#failed_files[@]} -gt 0 ]; then
     failed_list=$(printf '%s\n' "${failed_files[@]}")

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,1 +1,1 @@
-0 21 * * 5 TZ=America/New_York /home/nathan/github/mypersonalfinance/bin/parents-db-cron.sh >> /home/nathan/logs/parents-db-cron.log 2>&1
+0 21 * * 5 bash /home/nathan/git/mypersonalfinance/bin/parents-db-cron.sh >> ~/cron-logs/parents-db-cron.log 2>&1

--- a/load-excel-transactions.py
+++ b/load-excel-transactions.py
@@ -9,7 +9,7 @@ import requests
 
 from classes.db.parents_finance_db import ParentsFinanceDB
 
-RPI_IP = "195.168.1.7"
+RPI_IP = "10.20.0.8"
 DISCORD_ALERT_BOT_URL = f"http://{RPI_IP}:30007/alert"
 DEBUG = True
 


### PR DESCRIPTION
## Summary
- Update Discord notification endpoint from port 30008 to 30007
- Update NAS IP from 195.168.1.14 to 10.20.0.18
- Update crontab to use correct git path (`/home/nathan/git/`) and log directory (`~/cron-logs/`)

## Test plan
- [ ] Verify Discord notifications route correctly to port 30007
- [ ] Verify NAS FTP connection works with new IP 10.20.0.18
- [ ] Verify cron job runs and logs to `~/cron-logs/parents-db-cron.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)