### PR TITLE
fix(td-debit): add CPP/OAS/tax-refund to skip list, add skip to parents category prompt

### DIFF
--- a/classes/cc/td_debit.py
+++ b/classes/cc/td_debit.py
@@ -77,6 +77,9 @@ class TdDebitStatement(FileBasedCardStatement):
             "CAN TIRE MC",
             "CIBC MC",
             "EMPL INS         EI",
+            "CPP              CPP",
+            "TAX REFUND       RIT",
+            "OLD AGE SEC      OAS",
         ]
 
         # Filter out transactions from skip list

--- a/classes/db/parents_finance_db.py
+++ b/classes/db/parents_finance_db.py
@@ -92,6 +92,9 @@ class ParentsFinanceDB(FinanceDB):
             print(df)
             while True:
                 category_id = input("Enter the category id: ")
+                if category_id.strip().lower() == "skip":
+                    print("Skipping...")
+                    return 0
                 try:
                     category_id = int(category_id)
                     if category_id in df["id"].to_list():


### PR DESCRIPTION
## Summary

- `classes/cc/td_debit.py`: Added CPP, TAX REFUND (RIT), and OAS entries to the TD debit skip list so government/income transactions are filtered out
- `classes/db/parents_finance_db.py`: Added `skip` command support in the interactive category prompt, returning 0 to skip the transaction