### PR TITLE
feat: integrate SimplyFIN Bridge as online transaction source

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ uv run python load-transactions.py --type ws_debit --database finance
 uv run python load-transactions.py --type ws_credit --database finance
 ```
 
+load simplyfin bridge transactions (all connected bank accounts):
+```bash
+# one-time: get a setup token at https://beta-bridge.simplefin.org/simplefin/create
+# and add it to .env as SIMPLEFIN_SETUP_TOKEN
+uv run python load-transactions.py --type simplefin --database finance
+```
+
 load pre-categorized excel transactions:
 ```bash
 uv run python load-excel-transactions.py --filepath <path_to_excel>

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class Config:
     postgres_connection_string: str
     ws_debt_link: str
     ws_credit_link: str
+    simplefin_setup_token: str
     debug: bool
 
     def __init__(self, debug: bool = False):
@@ -17,8 +18,10 @@ class Config:
         self.postgres_connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
         self.ws_debt_link = os.getenv("WS_DEBIT_LINK")
         self.ws_credit_link = os.getenv("WS_CREDIT_LINK")
+        self.simplefin_setup_token = os.getenv("SIMPLEFIN_SETUP_TOKEN")
         self.debug = debug
         if self.debug:
             print(f"{self.postgres_connection_string=}")
             print(f"{self.ws_debt_link=}")
             print(f"{self.ws_credit_link=}")
+            print(f"{self.simplefin_setup_token=}")

--- a/env-sample
+++ b/env-sample
@@ -2,3 +2,5 @@
 POSTGRES_CONNECTION_STRING=postgresql://username:password@host_name_or_ip:postgres_port_number
 WS_DEBT_LINK=https://my.wealthsimple.com/copy-this-part-into-here
 WS_CREDIT_LINK=https://my.wealthsimple.com/copy-this-part-into-here
+# SimplyFIN Bridge: get token from https://beta-bridge.simplefin.org/simplefin/create
+SIMPLEFIN_SETUP_TOKEN=

--- a/scripts/test_simplefin.py
+++ b/scripts/test_simplefin.py
@@ -1,0 +1,36 @@
+"""
+Test script: fetch and print SimplyFIN Bridge transactions without DB writes.
+
+Usage:
+    uv run python scripts/test_simplefin.py
+"""
+
+import os
+import sys
+
+# Add project root to sys.path so `sources` package resolves
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import polars as pl
+
+from sources.api.simplefin import SimplefinStatement
+
+
+def main():
+    statement = SimplefinStatement()
+    df = statement.get_df()
+
+    pl.Config.set_tbl_cols(20)
+    pl.Config.set_tbl_rows(100)
+    pl.Config.set_fmt_str_lengths(1000)
+
+    if df.is_empty():
+        print("No transactions returned.")
+        return
+
+    print(f"\n{df.height} transactions fetched:\n")
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/sources/api/simplefin.py
+++ b/sources/api/simplefin.py
@@ -1,0 +1,117 @@
+import base64
+import datetime
+import os
+import stat
+
+import polars as pl
+import requests
+
+from sources.base import OnlineCardStatement
+
+# Path to persist the one-time-claimed Access URL.
+# The Access URL embeds Basic Auth credentials, so the file is chmod 600.
+ACCESS_URL_FILE = os.path.expanduser("~/.simplefin_access_url")
+
+BRIDGE_CREATE_URL = "https://beta-bridge.simplefin.org/simplefin/create"
+
+
+class SimplefinStatement(OnlineCardStatement):
+    def __init__(self):
+        super().__init__(type="simplefin")
+
+    def load_data(self) -> None:
+        setup_token = self.config.simplefin_setup_token
+        if not setup_token:
+            raise ValueError(
+                "SIMPLEFIN_SETUP_TOKEN not set. Get one at "
+                f"{BRIDGE_CREATE_URL} and add it to .env"
+            )
+
+        access_url = self._get_access_url(setup_token)
+        base_url, username, password = self._parse_access_url(access_url)
+        data = self._fetch_accounts(base_url, username, password)
+
+        rows = []
+        for account in data.get("accounts", []):
+            for txn in account.get("transactions", []):
+                posted = txn.get("posted", 0)
+                if not posted:
+                    # Pending or unposted transaction; skip — it'll settle and
+                    # appear as posted in a later fetch.
+                    continue
+                rows.append(
+                    {
+                        "date": datetime.datetime.fromtimestamp(posted).date(),
+                        "merchant": txn.get("description", ""),
+                        # Protocol: positive amount = deposit. Negate for the
+                        # project's expense convention (positive cost = expense).
+                        "cost": -float(txn.get("amount", "0")),
+                        "cc_category": None,
+                    }
+                )
+
+        self.df = pl.DataFrame(
+            rows,
+            schema={
+                "date": pl.Date,
+                "merchant": pl.Utf8,
+                "cost": pl.Float64,
+                "cc_category": pl.Utf8,
+            },
+        )
+
+    def _get_access_url(self, setup_token: str) -> str:
+        if os.path.exists(ACCESS_URL_FILE):
+            with open(ACCESS_URL_FILE) as f:
+                access_url = f.read().strip()
+            if access_url:
+                return access_url
+
+        access_url = self._claim_access_url(setup_token)
+        with open(ACCESS_URL_FILE, "w") as f:
+            f.write(access_url)
+        os.chmod(ACCESS_URL_FILE, stat.S_IRUSR | stat.S_IWUSR)
+        return access_url
+
+    def _claim_access_url(self, setup_token: str) -> str:
+        claim_url = base64.b64decode(setup_token).decode()
+        response = requests.post(claim_url)
+        if response.status_code == 403:
+            raise ValueError(
+                "SimpleFIN setup token already claimed or invalid. "
+                f"Get a new one at {BRIDGE_CREATE_URL}"
+            )
+        response.raise_for_status()
+        return response.text.strip()
+
+    def _parse_access_url(self, access_url: str) -> tuple[str, str, str]:
+        # Access URL form: https://user:pass@host/path
+        scheme, rest = access_url.split("//", 1)
+        auth, rest = rest.split("@", 1)
+        username, password = auth.split(":", 1)
+        base_url = f"{scheme}//{rest}"
+        return base_url, username, password
+
+    def _fetch_accounts(self, base_url: str, username: str, password: str) -> dict:
+        response = requests.get(
+            f"{base_url}/accounts",
+            auth=(username, password),
+            params={"version": "2"},
+        )
+        if response.status_code == 402:
+            raise ValueError("SimpleFIN: payment required")
+        if response.status_code == 403:
+            raise ValueError(
+                f"SimpleFIN access revoked. Get a new token at {BRIDGE_CREATE_URL}"
+            )
+        response.raise_for_status()
+        data = response.json()
+
+        # Protocol requires showing errors to the end user.
+        for err in data.get("errlist", []):
+            print(f"SimpleFIN error: {str(err.get('msg', '')).strip()}")
+        # Deprecated in v2 but still emitted by older servers.
+        for msg in data.get("errors", []):
+            print(f"SimpleFIN error: {str(msg).strip()}")
+
+        return data

--- a/sources/base.py
+++ b/sources/base.py
@@ -41,7 +41,7 @@ class OnlineCardStatement(ABC):
 
     def __init__(self, type: str):
         self.type = type
-        self.config = Config(debug=True)
+        self.config = Config()
         self.load_data()
 
     @abstractmethod

--- a/sources/registry.py
+++ b/sources/registry.py
@@ -87,6 +87,12 @@ CARD_TYPES = {
         "requires_file": False,
         "description": "Wealthsimple Credit",
     },
+    "simplefin": {
+        "module": "sources.api.simplefin",
+        "class_name": "SimplefinStatement",
+        "requires_file": False,
+        "description": "SimplyFIN Bridge (all connected bank accounts)",
+    },
 }
 
 


### PR DESCRIPTION
Implements the [SimpleFIN v2 protocol](https://www.simplefin.org/protocol.html) as a new online source.

### Changes
- `sources/api/simplefin.py` — `SimplefinStatement(OnlineCardStatement)`
- `config.py` + `env-sample` — add `SIMPLEFIN_SETUP_TOKEN`
- `sources/registry.py` — register `simplefin` card type (online, no file)
- `README.md` — document usage

### How it works
1. User gets a one-time setup token at https://beta-bridge.simplefin.org/simplefin/create
2. App base64-decodes it, POSTs to claim an Access URL (one-time), persists to `~/.simplefin_access_url` (chmod 600)
3. Subsequent runs read the cached Access URL, skip the claim
4. `GET {access_url}/accounts?version=2` with Basic Auth

### Protocol edge cases handled
- HTTP 403 on claim → token already claimed/invalid
- HTTP 403 on /accounts → access revoked
- HTTP 402 → payment required
- `errlist` + deprecated `errors` arrays printed to user
- Pending txns skipped by default (no `pending=1`; settle in next fetch)
- Amounts negated (protocol: positive = deposit; project: positive = expense)

### Usage
```bash
# set SIMPLEFIN_SETUP_TOKEN in .env
uv run python load-transactions.py --type simplefin --database finance
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SimpleFIN Bridge integration to connect and import transactions from all linked bank accounts via a simple one-time token setup process.

* **Documentation**
  * Updated README with detailed SimpleFIN Bridge setup guide, including instructions for obtaining the setup token and importing transactions from multiple accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->